### PR TITLE
AWS Lambda Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### VNEXT
 
 * Restify: Fix for calling next() (([@jadkap](https://github.com/jadkap)) on [#285](https://github.com/apollostack/graphql-server/pull/285))
+* Add AWS Lambda Integration [#101](https://github.com/apollostack/graphql-server/issues/101)
 
 ### v0.5.2
 * **Restify integration** ([@joelgriffith](https://github.com/joelgriffith)) on [#189](https://github.com/apollostack/graphql-server/pull/189)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ where variant is one of the following:
  - express
  - koa
  - hapi
+ - restify
  - lambda
 
 ### Express

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GraphQL Server for Express, Connect, Hapi, Koa, and Restify
+# GraphQL Server for Express, Connect, Hapi, Koa, Restify and AWS Lambda
 
 [![npm version](https://badge.fury.io/js/graphql-server-core.svg)](https://badge.fury.io/js/graphql-server-core)
 [![Build Status](https://travis-ci.org/apollostack/graphql-server.svg?branch=master)](https://travis-ci.org/apollostack/graphql-server)
@@ -31,6 +31,7 @@ where variant is one of the following:
  - express
  - koa
  - hapi
+ - lambda
 
 ### Express
 
@@ -153,7 +154,19 @@ server.get('/graphiql', graphiqlRestify({ endpointURL: '/graphql' }));
 server.listen(PORT, () => console.log(`Listening on ${PORT}`));
 ```
 
+### AWS Lambda
+
+Lambda function should be run with Node.js v4.3. Requires an API Gateway with Lambda Proxy Integration.
+
+```js
+var server = require("graphql-server-lambda");
+
+exports.handler = server.graphqlLambda({ schema: myGraphQLSchema });
+```
+
 ## Options
+
+=======
 
 GraphQL Server can be configured with an options object with the the following fields:
 

--- a/packages/graphql-server-lambda/.npmignore
+++ b/packages/graphql-server-lambda/.npmignore
@@ -1,0 +1,5 @@
+*
+!dist
+!dist/**/*
+dist/**/*.test.*
+!package.json

--- a/packages/graphql-server-lambda/README.md
+++ b/packages/graphql-server-lambda/README.md
@@ -1,3 +1,85 @@
 # graphql-server-lambda
 
 This is the AWS Lambda integration for the Apollo community GraphQL Server. [Read the docs.](http://dev.apollodata.com/tools/apollo-server/index.html)
+
+## How to Deploy
+### AWS Serverless Application Model (SAM)
+
+To deploy the AWS Lambda function we must create a Cloudformation Template and a S3 bucket to store the artifact (zip of source code) and template.
+
+We will use the [AWS Command Line Interface](https://aws.amazon.com/cli/).
+
+#### Write the API handlers
+graphql.js:
+```javascript
+var server = require("graphql-server-lambda"),
+    myGraphQLSchema = require("./schema");
+
+exports.graphqlHandler = server.graphqlLambda({ schema: myGraphQLSchema });
+exports.graphiqlHandler = server.graphiqlLambda({
+    endpointURL: '/Prod/graphql'
+});
+
+```
+
+#### Create a S3 bucket 
+
+The bucket name name must be universally unique.
+```
+aws s3 mb s3://<bucket name>
+```
+#### Create the Template
+This will look for a file called graphql.js with two exports: graphqlHandler and graphiqlHandler. It creates two API enpoints:
+- /graphql (GET and POST)
+- /graphiql (GET)
+
+template.yaml:
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  GraphQL:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: graphql.graphqlHandler
+      Runtime: nodejs4.3
+      Events:
+        GetRequest:
+          Type: Api
+          Properties:
+            Path: /graphql
+            Method: get
+        PostRequest:
+          Type: Api
+          Properties:
+            Path: /graphql
+            Method: post
+  GraphQLInspector:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: graphql.graphiqlHandler
+      Runtime: nodejs4.3
+      Events:
+        GetRequest:
+          Type: Api
+          Properties:
+            Path: /graphiql
+            Method: get
+
+```
+#### Pacakge source code and dependencies
+This will read and transform the template, created in previous step. Package and upload the artifact to the S3 bucket and generate another template for the deployment.
+```
+aws cloudformation package \
+   --template-file template.yaml \
+   --output-template-file serverless-output.yaml \
+   --s3-bucket <bucket-name>
+```
+#### Deploy the API
+The will create the Lambda Function and API Gateway for GraphQL. We use the stack-name prod to mean production but any stack name can be used.
+```
+aws cloudformation deploy \
+   --template-file serverless-output.yaml \
+   --stack-name prod \
+   --capabilities CAPABILITY_IAM
+```

--- a/packages/graphql-server-lambda/README.md
+++ b/packages/graphql-server-lambda/README.md
@@ -1,0 +1,3 @@
+# graphql-server-lambda
+
+This is the AWS Lambda integration for the Apollo community GraphQL Server. [Read the docs.](http://dev.apollodata.com/tools/apollo-server/index.html)

--- a/packages/graphql-server-lambda/package.json
+++ b/packages/graphql-server-lambda/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "graphql-server-lambda",
+  "version": "0.5.1",
+  "description": "Production-ready Node.js GraphQL server for AWS Lambda",
+  "main": "dist/index.js",
+  "scripts": {
+    "compile": "tsc",
+    "prepublish": "npm run compile"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apollostack/graphql-server/tree/master/packages/graphql-server-lambda"
+  },
+  "keywords": [
+    "GraphQL",
+    "Apollo",
+    "Server",
+    "Lambda",
+    "Javascript"
+  ],
+  "author": "Jonas Helfer <jonas@helfer.email>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/apollostack/graphql-server/issues"
+  },
+  "homepage": "https://github.com/apollostack/graphql-server#readme",
+  "dependencies": {
+    "graphql-server-core": "^0.5.1",
+    "graphql-server-module-graphiql": "^0.4.4"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "0.0.5",
+    "@types/graphql": "^0.8.6",
+    "graphql-server-integration-testsuite": "^0.5.1"
+  },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0"
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  }
+}

--- a/packages/graphql-server-lambda/src/index.ts
+++ b/packages/graphql-server-lambda/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  LambdaHandler,
+  IHeaders,
+  graphqlLambda,
+  graphiqlLambda
+} from './lambdaApollo';

--- a/packages/graphql-server-lambda/src/lambdaApollo.test.ts
+++ b/packages/graphql-server-lambda/src/lambdaApollo.test.ts
@@ -1,0 +1,64 @@
+import { graphqlLambda, graphiqlLambda } from './lambdaApollo';
+import testSuite, { schema as Schema, CreateAppOptions } from 'graphql-server-integration-testsuite';
+import { expect } from 'chai';
+import { GraphQLOptions } from 'graphql-server-core';
+import 'mocha';
+import * as url from 'url';
+
+function createLambda(options: CreateAppOptions = {}) {
+  let handler,
+    callback,
+    event,
+    context;
+
+  options.graphqlOptions = options.graphqlOptions || { schema: Schema };
+  if (options.graphiqlOptions ) {
+    handler = graphiqlLambda( options.graphiqlOptions );
+  } else {
+    handler = graphqlLambda( options.graphqlOptions );
+  }
+
+  return function(req, res) {
+    let body = '';
+    req.on('data', function (chunk) {
+      body += chunk;
+    });
+    req.on('end', function() {
+      let urlObject = url.parse(req.url, true);
+      event = {
+        httpMethod: req.method,
+        body: body,
+        path: req.url,
+        queryStringParameters: urlObject.query,
+      };
+      context = {};
+      callback = function(error, result) {
+        res.statusCode = result.statusCode;
+        for (let key in result.headers) {
+          if (result.headers.hasOwnProperty(key)) {
+            res.setHeader(key, result.headers[key]);
+          }
+        }
+        res.write(result.body);
+        res.end();
+      };
+
+      handler(event, context, callback);
+    });
+  };
+}
+
+describe('lambdaApollo', () => {
+  it('throws error if called without schema', function(){
+    expect(() => graphqlLambda(undefined as GraphQLOptions)).to.throw('Apollo Server requires options.');
+  });
+
+  it('throws an error if called with more than one argument', function(){
+    expect(() => (<any>graphqlLambda)({}, {})).to.throw(
+       'Apollo Server expects exactly one argument, got 2');
+  });
+});
+
+describe('integration:Lambda', () => {
+  testSuite(createLambda);
+});

--- a/packages/graphql-server-lambda/src/lambdaApollo.ts
+++ b/packages/graphql-server-lambda/src/lambdaApollo.ts
@@ -1,0 +1,106 @@
+import * as lambda from 'aws-lambda';
+import { GraphQLOptions, runHttpQuery } from 'graphql-server-core';
+import * as GraphiQL from 'graphql-server-module-graphiql';
+
+export interface LambdaGraphQLOptionsFunction {
+  (event: any, context: lambda.Context): GraphQLOptions | Promise<GraphQLOptions>;
+}
+
+// Design principles:
+// - there is just one way allowed: POST request with JSON body. Nothing else.
+// - simple, fast and secure
+//
+
+export interface LambdaHandler {
+  (event: any, context: lambda.Context, callback: lambda.Callback): void;
+}
+
+export interface IHeaders {
+    [header: string]: string | number;
+}
+
+export function graphqlLambda( options: GraphQLOptions | LambdaGraphQLOptionsFunction ): LambdaHandler {
+  if (!options) {
+    throw new Error('Apollo Server requires options.');
+  }
+
+  if (arguments.length > 1) {
+    throw new Error(`Apollo Server expects exactly one argument, got ${arguments.length}`);
+  }
+
+  return async (event, lambdaContext: lambda.Context, callback: lambda.Callback) => {
+    let query = (event.httpMethod === 'POST') ? event.body : event.queryStringParameters,
+      statusCode: number = null,
+      gqlResponse = null,
+      headers: {[headerName: string]: string} = {};
+
+    if (query && typeof query === 'string') {
+      query = JSON.parse(query);
+    }
+
+    try {
+      gqlResponse = await runHttpQuery([event, lambdaContext], {
+        method: event.httpMethod,
+        options: options,
+        query: query,
+      });
+      headers['Content-Type'] = 'application/json';
+      statusCode = 200;
+    } catch (error) {
+      if ( 'HttpQueryError' !== error.name ) {
+        throw error;
+      }
+
+      headers = error.headers;
+      statusCode = error.statusCode;
+      gqlResponse = error.message;
+    } finally {
+      callback(
+        null,
+        {
+          'statusCode': statusCode,
+          'headers': headers,
+          'body': gqlResponse,
+        },
+      );
+    }
+  };
+}
+
+/* This Lambda Function Handler returns the html for the GraphiQL interactive query UI
+ *
+ * GraphiQLData arguments
+ *
+ * - endpointURL: the relative or absolute URL for the endpoint which GraphiQL will make queries to
+ * - (optional) query: the GraphQL query to pre-fill in the GraphiQL UI
+ * - (optional) variables: a JS object of variables to pre-fill in the GraphiQL UI
+ * - (optional) operationName: the operationName to pre-fill in the GraphiQL UI
+ * - (optional) result: the result of the query to pre-fill in the GraphiQL UI
+ */
+
+export function graphiqlLambda(options: GraphiQL.GraphiQLData) {
+  return (event, lambdaContext: lambda.Context, callback: lambda.Callback) => {
+    const q = event.queryStringParameters || {};
+    const query = q.query || '';
+    const variables = q.variables || '{}';
+    const operationName = q.operationName || '';
+
+    const graphiQLString = GraphiQL.renderGraphiQL({
+      endpointURL: options.endpointURL,
+      query: query || options.query,
+      variables: q.variables && JSON.parse(variables) || options.variables,
+      operationName: operationName || options.operationName,
+      passHeader: options.passHeader,
+    });
+    callback(
+      null,
+      {
+        'statusCode': 200,
+        'headers': {
+          'Content-Type': 'text/html',
+        },
+        'body': graphiQLString,
+      },
+    );
+  };
+}

--- a/packages/graphql-server-lambda/tsconfig.json
+++ b/packages/graphql-server-lambda/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "typeRoots": [
+        "node_modules/@types"
+    ],
+    "types": [
+        "@types/node"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,4 +7,5 @@ require('../packages/graphql-server-express/dist/connectApollo.test');
 require('../packages/graphql-server-hapi/dist/hapiApollo.test');
 require('../packages/graphql-server-koa/dist/koaApollo.test');
 require('../packages/graphql-server-restify/dist/restifyApollo.test');
+require('../packages/graphql-server-lambda/dist/lambdaApollo.test');
 require('../packages/graphql-server-express/dist/apolloServerHttp.test');


### PR DESCRIPTION
This adds the AWS lambda integration for Apollo Server. This requires a Lambda function that is attached to an API Gateway using the Lambda Proxy Integration. I had to add another parameter to the server to pass in headers. Headers to allow cross origin calls cannot be set when using Lambda Proxy Integration mode and must be passed in when calling the callback function.

To allow for the tests to pass I had to mock out the req and res objects that are required by the test suite. I thought this was easier than copying all the tests. I still get errors printed out, from uncaught exceptions, still looking into why.

I will add an example and some documentation to the README file and complete all the todo tasks below.

Closes #101

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
