### PR TITLE
Update GraphiQL version to 0.9.1

### DIFF
--- a/packages/graphql-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/graphql-server-module-graphiql/src/renderGraphiQL.ts
@@ -28,7 +28,7 @@ export type GraphiQLData = {
 };
 
 // Current latest version of GraphiQL.
-const GRAPHIQL_VERSION = '0.8.0';
+const GRAPHIQL_VERSION = '0.9.1';
 
 // Ensures string values are safe to be used within a <script> tag.
 // TODO: I don't think that's the right escape function


### PR DESCRIPTION
I have just spent a couple of hours trying to get deprecation directives (among other things) working in `graphql-server`. The last of these issues had me wondering why  https://github.com/graphql/graphiql/issues/273 was closed but seemingly not working/implemented, even after upgrading to the latest package versions of graphql-server, graphiql, graphql-tools etc.

The issue is that the locally installed GraphQL implementation is not used at all and `graphql-server` seems to do its own dependency management instead. 

Is it possible to just `import 'graphiql'`? and add `graphiql` as a peer dependency to `graphql-server`? What edge cases was the current implementation intending to fix?

In the meantime, is it reasonable to just upgrade the GraphiQL version like this? There appear to have been efforts to make GraphiQL versions backwards compatible, but I'm far from an expert on it.