### PR TITLE
Disable Koa integration test for NodeJS v4

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -1,3 +1,5 @@
+const NODE_VERSION = process.version.split('.');
+const NODE_MAJOR_VERSION = parseInt(NODE_VERSION[0].replace(/^v/, ''));
 process.env.NODE_ENV = 'test';
 
 require('../packages/graphql-server-core/dist/runQuery.test.js');
@@ -5,7 +7,9 @@ require('../packages/graphql-server-module-operation-store/dist/operationStore.t
 require('../packages/graphql-server-express/dist/expressApollo.test');
 require('../packages/graphql-server-express/dist/connectApollo.test');
 require('../packages/graphql-server-hapi/dist/hapiApollo.test');
-require('../packages/graphql-server-koa/dist/koaApollo.test');
+if (NODE_MAJOR_VERSION >= 6) {
+    require('../packages/graphql-server-koa/dist/koaApollo.test');
+}
 require('../packages/graphql-server-restify/dist/restifyApollo.test');
 require('../packages/graphql-server-lambda/dist/lambdaApollo.test');
 require('../packages/graphql-server-express/dist/apolloServerHttp.test');


### PR DESCRIPTION
Newer versions of Koa use features of ES6 that are not supported in
nodejs v4. This commits enables the Koa integration test only when run
on nodejs v6 or newer.

Stacktrace of error on nodejs v4:
```
/home/travis/build/apollographql/graphql-server/packages/graphql-server-koa/node_modules/koa/lib/response.js:47
    const { res } = this;
          ^
SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Module.replacementCompile (/home/travis/build/apollographql/graphql-server/node_modules/append-transform/index.js:58:13)
    at Module._extensions..js (module.js:416:10)
    at Object.<anonymous> (/home/travis/build/apollographql/graphql-server/node_modules/append-transform/index.js:62:4)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/travis/build/apollographql/graphql-server/packages/graphql-server-koa/node_modules/koa/lib/application.js:11:18)
```
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
