### PR TITLE
Lerna release pipeline

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0-beta.38",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "changelog": {
     "repo": "apollostack/graphql-server",
     "labels": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "travis": "istanbul cover -x \"*.test.js\" _mocha -- --timeout 5000 --full-trace ./test/tests.js",
     "posttravis": "npm run lint",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
-    "check-updates": "lerna exec ./node_modules/.bin/npm-check-updates -- -u"
+    "check-updates": "ncu -u && lerna exec ../../node_modules/.bin/ncu -- -u",
+    "postcheck-updates": "npm test && npm run commit-updates",
+    "commit-updates": "git add \"packages/*/package.json\" package.json; git commit -m \"Update dependencies\" || exit 0",
+    "prerelease": "npm run check-updates",
+    "release": "lerna publish"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/packages/graphql-server-core/package.json
+++ b/packages/graphql-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/graphql-server-express/package.json
+++ b/packages/graphql-server-express/package.json
@@ -30,13 +30,13 @@
     "graphql-server-module-graphiql": "^0.6.0"
   },
   "devDependencies": {
-    "@types/body-parser": "0.0.33",
+    "@types/body-parser": "1.16.1",
     "@types/connect": "^3.4.30",
     "@types/express": "^4.0.35",
     "@types/multer": "0.0.33",
     "body-parser": "^1.16.0",
     "connect": "^3.5.0",
-    "connect-query": "^0.2.0",
+    "connect-query": "^1.0.0",
     "express": "^4.14.0",
     "graphql-server-integration-testsuite": "^0.6.0",
     "multer": "^1.2.1"

--- a/packages/graphql-server-express/package.json
+++ b/packages/graphql-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-express",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "scripts": {
@@ -38,7 +38,7 @@
     "connect": "^3.5.0",
     "connect-query": "^0.2.0",
     "express": "^4.14.0",
-    "graphql-server-integration-testsuite": "^0.5.1",
+    "graphql-server-integration-testsuite": "^0.6.0",
     "multer": "^1.2.1"
   },
   "peerDependencies": {

--- a/packages/graphql-server-hapi/package.json
+++ b/packages/graphql-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-hapi",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "scripts": {
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/boom": "0.0.33",
     "@types/hapi": "^16.0.0",
-    "graphql-server-integration-testsuite": "^0.5.1",
+    "graphql-server-integration-testsuite": "^0.6.0",
     "hapi": "^16.1.0",
     "@types/graphql": "^0.8.5"
   },

--- a/packages/graphql-server-integration-testsuite/package.json
+++ b/packages/graphql-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-server-integration-testsuite",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/graphql-server-koa/package.json
+++ b/packages/graphql-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-koa",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "@types/koa": "^2.0.33",
     "@types/koa-bodyparser": "^3.0.19",
     "@types/koa-router": "^7.0.21",
-    "graphql-server-integration-testsuite": "^0.5.1",
+    "graphql-server-integration-testsuite": "^0.6.0",
     "koa": "^2.0.0-alpha.4",
     "koa-bodyparser": "^3.0.0",
     "koa-router": "^7.0.1"

--- a/packages/graphql-server-koa/package.json
+++ b/packages/graphql-server-koa/package.json
@@ -34,7 +34,7 @@
     "@types/koa-router": "^7.0.21",
     "graphql-server-integration-testsuite": "^0.6.0",
     "koa": "^2.0.0-alpha.4",
-    "koa-bodyparser": "^3.0.0",
+    "koa-bodyparser": "^3.2.0",
     "koa-router": "^7.0.1"
   },
   "peerDependencies": {

--- a/packages/graphql-server-lambda/package.json
+++ b/packages/graphql-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-lambda",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "main": "dist/index.js",
   "scripts": {
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/aws-lambda": "0.0.6",
     "@types/graphql": "^0.8.6",
-    "graphql-server-integration-testsuite": "^0.5.1"
+    "graphql-server-integration-testsuite": "^0.6.0"
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0"

--- a/packages/graphql-server-lambda/package.json
+++ b/packages/graphql-server-lambda/package.json
@@ -29,7 +29,7 @@
     "graphql-server-module-graphiql": "^0.6.0"
   },
   "devDependencies": {
-    "@types/aws-lambda": "0.0.6",
+    "@types/aws-lambda": "0.0.9",
     "@types/graphql": "^0.8.6",
     "graphql-server-integration-testsuite": "^0.6.0"
   },

--- a/packages/graphql-server-module-graphiql/package.json
+++ b/packages/graphql-server-module-graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-module-graphiql",
-  "version": "0.4.4",
+  "version": "0.6.0",
   "description": "GraphiQL renderer for Apollo GraphQL Server",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/graphql-server-module-operation-store/package.json
+++ b/packages/graphql-server-module-operation-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-module-operation-store",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Persisted operation store module for Apollo GraphQL Servers",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/graphql-server-restify/package.json
+++ b/packages/graphql-server-restify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-server-restify",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Production-ready Node.js GraphQL server for Restify",
   "main": "dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/restify": "^2.0.38",
-    "graphql-server-integration-testsuite": "^0.5.1",
+    "graphql-server-integration-testsuite": "^0.6.0",
     "restify": "^4.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Looks like there was a release without lerna pipe, this causes confusion as boostraping takes npm versions and not local versions.
I've aligned everything again so lerna will work as expected.

from now on, please use `npm run release` to release new versions.

TODO - Not needed i assume?:

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

will be taken out of #308