### PR TITLE
Update ts-lint to version 5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sinon": "^2.0.0",
     "supertest": "^3.0.0",
     "supertest-as-promised": "^4.0.2",
-    "tslint": "^4.3.1",
+    "tslint": "^5.0.0",
     "typescript": "^2.1.5"
   }
 }

--- a/packages/graphql-server-core/src/index.ts
+++ b/packages/graphql-server-core/src/index.ts
@@ -1,3 +1,3 @@
-export { runQuery, LogFunction, LogMessage, LogStep, LogAction } from './runQuery'
+export { runQuery, LogFunction, LogMessage, LogStep, LogAction } from './runQuery';
 export { runHttpQuery, HttpQueryRequest, HttpQueryError } from './runHttpQuery';
-export { default as GraphQLOptions } from './graphqlOptions'
+export { default as GraphQLOptions } from './graphqlOptions';

--- a/packages/graphql-server-core/src/runQuery.test.ts
+++ b/packages/graphql-server-core/src/runQuery.test.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:no-unused-expression */
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import 'mocha';

--- a/packages/graphql-server-lambda/src/index.ts
+++ b/packages/graphql-server-lambda/src/index.ts
@@ -2,5 +2,5 @@ export {
   LambdaHandler,
   IHeaders,
   graphqlLambda,
-  graphiqlLambda
+  graphiqlLambda,
 } from './lambdaApollo';

--- a/tslint.json
+++ b/tslint.json
@@ -56,7 +56,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "no-var-requires": true,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
- Fix missing semicolons
- Fix missing trailing commas
- Disable no-unused-expression for runQuery test
    - expect uses unused expressions as an api Ex. expect('foo').to.be.equal();
- Disable no-use-before-declare since it requires type checking and project
  file to be defined.

Closes #342 
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
