### PR TITLE
Remove link for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ where variant is one of the following:
  - hapi
  - restify
  - lambda
- - [micro](https://github.com/zeit/micro)
+ - micro
 
 ### Express
 


### PR DESCRIPTION
None of the other list items are links, so I thought it best to remove this one as well. Alternatively we could also turn them all into links, but I don't think that's necessary and might even be distracting.