### PR TITLE
Append `location.hash` to history navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### VNEXT
-
+* Persist `window.location.hash` on URL updates [#386](https://github.com/apollographql/graphql-server/issues/386)
 
 ### v0.7.2
 * Fix include passHeader field that was accidentally removed

--- a/packages/graphql-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/graphql-server-module-graphiql/src/renderGraphiQL.ts
@@ -155,7 +155,7 @@ export function renderGraphiQL(data: GraphiQLData): string {
       updateURL();
     }
     function updateURL() {
-      history.replaceState(null, null, locationQuery(parameters));
+      history.replaceState(null, null, locationQuery(parameters) + window.location.hash);
     }
     // Render <GraphiQL /> into the body.
     ReactDOM.render(


### PR DESCRIPTION
Closes https://github.com/apollographql/graphql-server/issues/386. I can put this behind an option flag if needed. I'm pretty indifferent about actually disabling the behaviour (I can see it being useful), but can do that instead if that's a better decision.

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
