### PR TITLE
Fix Micro server handler

### DIFF
--- a/packages/graphql-server-integration-testsuite/src/index.ts
+++ b/packages/graphql-server-integration-testsuite/src/index.ts
@@ -817,5 +817,20 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           });
       });
     });
+
+    describe('server setup', () => {
+      it('throws error on 404 routes', () => {
+          app = createApp();
+
+          const query = {
+              query: '{ testString }',
+          };
+          const req = request(app)
+              .get(`/bogus-route?${querystring.stringify(query)}`);
+          return req.then((res) => {
+              expect(res.status).to.equal(404);
+          });
+      });
+    });
   });
 };

--- a/packages/graphql-server-lambda/src/lambdaApollo.test.ts
+++ b/packages/graphql-server-lambda/src/lambdaApollo.test.ts
@@ -6,19 +6,28 @@ import 'mocha';
 import * as url from 'url';
 
 function createLambda(options: CreateAppOptions = {}) {
-  let handler,
+  let route,
+    handler,
     callback,
     event,
     context;
 
   options.graphqlOptions = options.graphqlOptions || { schema: Schema };
   if (options.graphiqlOptions ) {
+    route = '/graphiql';
     handler = graphiqlLambda( options.graphiqlOptions );
   } else {
+    route = '/graphql';
     handler = graphqlLambda( options.graphqlOptions );
   }
 
   return function(req, res) {
+    if (!req.url.startsWith(route)) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+
     let body = '';
     req.on('data', function (chunk) {
       body += chunk;

--- a/packages/graphql-server-micro/README.md
+++ b/packages/graphql-server-micro/README.md
@@ -1,3 +1,25 @@
 # graphql-server-micro
 
 This is the [Micro](https://github.com/zeit/micro) integration for the Apollo community GraphQL Server. [Read the docs.](http://dev.apollodata.com/tools/apollo-server/index.html)
+
+
+## Example
+```typescript
+import { microGraphiql, microGraphql } from "graphql-server-micro";
+import micro, { send } from "micro";
+import { get, post, router } from "microrouter";
+import schema from "./schema";
+
+const graphqlHandler: microGraphql({ schema });
+
+const server = micro(
+  router(
+    get("/graphql", graphqlHandler),
+    post("/graphql", graphqlHandler),
+    get("/graphiql", microGraphiql({ endpointURL: "/graphql" })),
+    (req, res) => send(res, 404, "404 Not found."),
+  ),
+);
+
+server.listen(3000);
+```

--- a/packages/graphql-server-micro/README.md
+++ b/packages/graphql-server-micro/README.md
@@ -10,14 +10,15 @@ import micro, { send } from "micro";
 import { get, post, router } from "microrouter";
 import schema from "./schema";
 
-const graphqlHandler: microGraphql({ schema });
+const graphqlHandler = microGraphql({ schema });
+const graphiqlHandler = microGraphiql({ endpointURL: "/graphql" });
 
 const server = micro(
   router(
     get("/graphql", graphqlHandler),
     post("/graphql", graphqlHandler),
-    get("/graphiql", microGraphiql({ endpointURL: "/graphql" })),
-    (req, res) => send(res, 404, "404 Not found."),
+    get("/graphiql", graphiqlHandler),
+    (req, res) => send(res, 404, "not found"),
   ),
 );
 

--- a/packages/graphql-server-micro/package.json
+++ b/packages/graphql-server-micro/package.json
@@ -37,7 +37,8 @@
     "micro": "^7.3.3"
   },
   "optionalDependencies": {
-    "@types/graphql": "^0.9.1"
+    "@types/graphql": "^0.9.1",
+    "@types/micro": "^7.3.0"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/graphql-server-micro/package.json
+++ b/packages/graphql-server-micro/package.json
@@ -30,7 +30,8 @@
   },
   "devDependencies": {
     "graphql-server-integration-testsuite": "^0.8.4",
-    "micro": "^7.3.3"
+    "micro": "^7.3.3",
+    "microrouter": "^2.1.1"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1",

--- a/packages/graphql-server-micro/src/microApollo.test.ts
+++ b/packages/graphql-server-micro/src/microApollo.test.ts
@@ -1,16 +1,39 @@
 import { microGraphql, microGraphiql } from './microApollo';
 import 'mocha';
 
-import micro from 'micro';
-import testSuite, { schema as Schema, CreateAppOptions  } from 'graphql-server-integration-testsuite';
+import micro, { send } from 'micro';
+import { router, get, post, put, patch, del, head, options as opts } from 'microrouter';
+import testSuite, { schema, CreateAppOptions  } from 'graphql-server-integration-testsuite';
+
 
 function createApp(options: CreateAppOptions) {
-    if (options && options.graphiqlOptions ) {
-        return micro(microGraphiql(options.graphiqlOptions));
-    } else {
-        const graphqlOptions = (options && options.graphqlOptions) || { schema: Schema };
-        return micro(microGraphql(graphqlOptions));
-    }
+    const graphqlOptions = (options && options.graphqlOptions) || { schema };
+    const graphiqlOptions = (options && options.graphiqlOptions) || { endpointURL: '/graphql' };
+
+    const graphqlHandler = microGraphql(graphqlOptions);
+    const graphiqlHandler = microGraphiql(graphiqlOptions);
+
+    return micro(
+        router(
+            get('/graphql', graphqlHandler),
+            post('/graphql', graphqlHandler),
+            put('/graphql', graphqlHandler),
+            patch('/graphql', graphqlHandler),
+            del('/graphql', graphqlHandler),
+            head('/graphql', graphqlHandler),
+            opts('/graphql', graphqlHandler),
+
+            get('/graphiql', graphiqlHandler),
+            post('/graphiql', graphiqlHandler),
+            put('/graphiql', graphiqlHandler),
+            patch('/graphiql', graphiqlHandler),
+            del('/graphiql', graphiqlHandler),
+            head('/graphiql', graphiqlHandler),
+            opts('/graphiql', graphiqlHandler),
+
+            (req, res) => send(res, 404, 'not found'),
+        ),
+    );
 }
 
 describe('integration:Micro', () => {

--- a/packages/graphql-server-micro/src/microApollo.test.ts
+++ b/packages/graphql-server-micro/src/microApollo.test.ts
@@ -1,12 +1,12 @@
 import { microGraphql, microGraphiql } from './microApollo';
 import 'mocha';
 
-import * as micro from 'micro';
+import micro from 'micro';
 import testSuite, { schema as Schema, CreateAppOptions  } from 'graphql-server-integration-testsuite';
 
 function createApp(options: CreateAppOptions) {
     if (options && options.graphiqlOptions ) {
-        return micro(microGraphiql( options.graphiqlOptions ));
+        return micro(microGraphiql(options.graphiqlOptions));
     } else {
         const graphqlOptions = (options && options.graphqlOptions) || { schema: Schema };
         return micro(microGraphql(graphqlOptions));


### PR DESCRIPTION
The handler was not returning `httpRunQuery`'s Promise, causing micro to send empty responses and leaving Node with unhandled Promise rejections when that Promise tried to write headers.

I also used `return` and `throw` instead of manipulating the response directly.  This allows wrapping middleware to intercept responses if desired.