### PR TITLE
Do not include types in koa, restify

### DIFF
--- a/packages/graphql-server-koa/tsconfig.json
+++ b/packages/graphql-server-koa/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "typeRoots": [
-      "node_modules/@types"
-    ]
+    "types": []
   },
   "exclude": [
     "node_modules",

--- a/packages/graphql-server-restify/tsconfig.json
+++ b/packages/graphql-server-restify/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "typeRoots": [
-      "node_modules/@types"
-    ]
+    "types": []
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Had to do this to get things to compile with tsc. Otherwise I'd get duplicate typings.
