### PR TITLE
Fixes broken graphiql endpoint

### DIFF
--- a/packages/graphql-server-koa/src/koaApollo.ts
+++ b/packages/graphql-server-koa/src/koaApollo.ts
@@ -51,7 +51,7 @@ export interface KoaGraphiQLOptionsFunction {
 export function graphiqlKoa(options: GraphiQL.GraphiQLData | KoaGraphiQLOptionsFunction) {
   return (ctx: koa.Context) => {
     const query = ctx.request.query;
-    GraphiQL.resolveGraphiQLString(query, options, ctx).then(graphiqlString => {
+    return GraphiQL.resolveGraphiQLString(query, options, ctx).then(graphiqlString => {
       ctx.set('Content-Type', 'text/html');
       ctx.body = graphiqlString;
     }, error => {


### PR DESCRIPTION
It looks like a recent change broke the graphiql endpoint by no longer returning the promise.