### PR TITLE
fix(graphql-server-micro): micro-router requires one 200 route

### DIFF
--- a/packages/graphql-server-micro/README.md
+++ b/packages/graphql-server-micro/README.md
@@ -18,6 +18,12 @@ const server = micro(
     get("/graphql", graphqlHandler),
     post("/graphql", graphqlHandler),
     get("/graphiql", graphiqlHandler),
+    get("/noop", (req, res) => {
+      // Micro router requires at least one 200 route
+      // or you will always get a 404
+      return send(res, 200, "");
+    }),
+    
     (req, res) => send(res, 404, "not found"),
   ),
 );


### PR DESCRIPTION
Fixes #449 for now by adding a noop route to the example so that graphiql does not 404.

Note that this is not a code change and as such I have not included it in the changelog. Please let me know if this is incorrect.
