### PR TITLE
Using await on graphiql handler - Fix graphiql issues

### DIFF
--- a/packages/graphql-server-micro/README.md
+++ b/packages/graphql-server-micro/README.md
@@ -18,12 +18,6 @@ const server = micro(
     get("/graphql", graphqlHandler),
     post("/graphql", graphqlHandler),
     get("/graphiql", graphiqlHandler),
-    get("/noop", (req, res) => {
-      // Micro router requires at least one 200 route
-      // or you will always get a 404
-      return send(res, 200, "");
-    }),
-    
     (req, res) => send(res, 404, "not found"),
   ),
 );

--- a/packages/graphql-server-micro/src/microApollo.ts
+++ b/packages/graphql-server-micro/src/microApollo.ts
@@ -61,16 +61,22 @@ export interface MicroGraphiQLOptionsFunction {
 }
 
 export function microGraphiql(options: GraphiQL.GraphiQLData | MicroGraphiQLOptionsFunction): RequestHandler {
-  return (req: IncomingMessage, res: ServerResponse) => {
+  return async (req: IncomingMessage, res: ServerResponse) => {
     const query = req.url && url.parse(req.url, true).query || {};
-    GraphiQL.resolveGraphiQLString(query, options, req).then(graphiqlString => {
-      res.setHeader('Content-Type', 'text/html');
-      res.write(graphiqlString);
-      res.end();
-    }, error => {
+    let graphiqlString;
+
+    try {
+      graphiqlString = await GraphiQL.resolveGraphiQLString(query, options, req);
+    } catch (error) {
       res.statusCode = 500;
       res.write(error.message);
       res.end();
-    });
+      return;
+    }
+
+    res.setHeader('Content-Type', 'text/html');
+    res.write(graphiqlString);
+    res.end();
+    return;
   };
 }

--- a/packages/graphql-server-micro/src/microApollo.ts
+++ b/packages/graphql-server-micro/src/microApollo.ts
@@ -61,22 +61,16 @@ export interface MicroGraphiQLOptionsFunction {
 }
 
 export function microGraphiql(options: GraphiQL.GraphiQLData | MicroGraphiQLOptionsFunction): RequestHandler {
-  return async (req: IncomingMessage, res: ServerResponse) => {
+  return (req: IncomingMessage, res: ServerResponse) => {
     const query = req.url && url.parse(req.url, true).query || {};
-    let graphiqlString;
-
-    try {
-      graphiqlString = await GraphiQL.resolveGraphiQLString(query, options, req);
-    } catch (error) {
+    return GraphiQL.resolveGraphiQLString(query, options, req).then(graphiqlString => {
+      res.setHeader('Content-Type', 'text/html');
+      res.write(graphiqlString);
+      res.end();
+    }, error => {
       res.statusCode = 500;
       res.write(error.message);
       res.end();
-      return;
-    }
-
-    res.setHeader('Content-Type', 'text/html');
-    res.write(graphiqlString);
-    res.end();
-    return;
+    });
   };
 }


### PR DESCRIPTION
This solves issue #449 without workarounds on microrouter definitions.

**This is a proposal! Please review the code before merging!** (It's my first experience with typescript, maybe also the README must be reviewed)
I was not able to provide tests for this use case, but the diff consists on a refactor to the graphiql handler. It use an async function so the microroute awaits the execution of the handler before  responds with a 404