### PR TITLE
adding in the callback to express package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### VNEXT
 
+### v1.0.1
+* Fix Express package not calling the callback on completion ([@chemdrew](https://github.com/chemdrew)) in [#463](https://github.com/apollographql/graphql-server/pull/463)
+
 ### v1.0.0
 * Add package readmes for Express, Hapi, Koa, Restify ([@helfer](https://github.com/helfer)) in [#442](https://github.com/apollographql/graphql-server/pull/442)
 * Updated & fixed typescript typings ([@helfer](https://github.com/helfer)) in [#440](https://github.com/apollographql/graphql-server/pull/440)

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "changelog": {
     "repo": "apollostack/graphql-server",
     "labels": {

--- a/packages/graphql-server-express/src/expressApollo.ts
+++ b/packages/graphql-server-express/src/expressApollo.ts
@@ -35,6 +35,7 @@ export function graphqlExpress(options: GraphQLOptions | ExpressGraphQLOptionsFu
       res.setHeader('Content-Type', 'application/json');
       res.write(gqlResponse);
       res.end();
+      next();
     }, (error: HttpQueryError) => {
       if ( 'HttpQueryError' !== error.name ) {
         return next(error);
@@ -49,6 +50,7 @@ export function graphqlExpress(options: GraphQLOptions | ExpressGraphQLOptionsFu
       res.statusCode = error.statusCode;
       res.write(error.message);
       res.end();
+      next(false);
     });
   };
 }


### PR DESCRIPTION
This is in relation to [issue 462](https://github.com/apollographql/graphql-server/issues/462)

Logic now matches the logic in the Restify package more closely.


TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
